### PR TITLE
Do not rely on system culture for parsing

### DIFF
--- a/IonDotnet.Bench/ExpressionExp.cs
+++ b/IonDotnet.Bench/ExpressionExp.cs
@@ -43,7 +43,7 @@ namespace IonDotnet.Bench
                     Description = "Measure performance impact of boxing",
                     Result = ExperimentResult.Failure,
                     SampleData = new byte[100],
-                    Budget = decimal.Parse("12345.01234567890123456789"),
+                    Budget = decimal.Parse("12345.01234567890123456789", System.Globalization.CultureInfo.InvariantCulture),
                     Outputs = new[] {1, 2, 3}
                 }
             });
@@ -60,7 +60,7 @@ namespace IonDotnet.Bench
                     Description = "Measure performance impact of boxing",
                     Result = ExperimentResult.Failure,
                     SampleData = new byte[100],
-                    Budget = decimal.Parse("12345.01234567890123456789")
+                    Budget = decimal.Parse("12345.01234567890123456789", System.Globalization.CultureInfo.InvariantCulture)
                 }
             });
             //            Console.WriteLine(string.Join(',', s.Select(b => $"{b:x2}")));

--- a/IonDotnet.Bench/SerializerGround.cs
+++ b/IonDotnet.Bench/SerializerGround.cs
@@ -132,7 +132,7 @@ namespace IonDotnet.Bench
                         Description = "Measure performance impact of boxing",
                         Result = ExperimentResult.Failure,
                         SampleData = new byte[100],
-                        Budget = decimal.Parse("12345.01234567890123456789")
+                        Budget = decimal.Parse("12345.01234567890123456789", System.Globalization.CultureInfo.InvariantCulture)
                     });
                 }
 

--- a/IonDotnet.Tests/Internals/BinaryWriterTest.cs
+++ b/IonDotnet.Tests/Internals/BinaryWriterTest.cs
@@ -48,7 +48,7 @@ namespace IonDotnet.Tests.Internals
         [DataRow("-3.01234567890123456789")]
         public void WriteSingleDecimal(string format)
         {
-            var val = decimal.Parse(format);
+            var val = decimal.Parse(format, System.Globalization.CultureInfo.InvariantCulture);
 
             Console.WriteLine(val);
 

--- a/IonDotnet/Internals/Text/SystemTextReader.cs
+++ b/IonDotnet/Internals/Text/SystemTextReader.cs
@@ -84,11 +84,11 @@ namespace IonDotnet.Internals.Text
                             SetInteger(Radix.Decimal, s);
                             break;
                         case IonType.Decimal:
-                            _v.DecimalValue = decimal.Parse(s);
+                            _v.DecimalValue = decimal.Parse(s, System.Globalization.CultureInfo.InvariantCulture);
 
                             break;
                         case IonType.Float:
-                            _v.DoubleValue = double.Parse(s);
+                            _v.DoubleValue = double.Parse(s, System.Globalization.CultureInfo.InvariantCulture);
                             break;
                         case IonType.Timestamp:
                             _v.TimestampValue = Timestamp.Parse(s);
@@ -106,10 +106,10 @@ namespace IonDotnet.Internals.Text
                     SetInteger(Radix.Hex, s);
                     break;
                 case TextConstants.TokenDecimal:
-                    _v.DecimalValue = decimal.Parse(s);
+                    _v.DecimalValue = decimal.Parse(s, System.Globalization.CultureInfo.InvariantCulture);
                     break;
                 case TextConstants.TokenFloat:
-                    _v.DoubleValue = double.Parse(s);
+                    _v.DoubleValue = double.Parse(s, System.Globalization.CultureInfo.InvariantCulture);
                     break;
                 case TextConstants.TokenTimestamp:
                     _v.TimestampValue = Timestamp.Parse(s);
@@ -184,13 +184,13 @@ namespace IonDotnet.Internals.Text
             //bigint
             if (intBase == 10)
             {
-                _v.BigIntegerValue = BigInteger.Parse(s);
+                _v.BigIntegerValue = BigInteger.Parse(s, System.Globalization.CultureInfo.InvariantCulture);
                 return;
             }
 
             if (intBase == 16)
             {
-                _v.BigIntegerValue = BigInteger.Parse(s, NumberStyles.HexNumber);
+                _v.BigIntegerValue = BigInteger.Parse(s, NumberStyles.HexNumber, System.Globalization.CultureInfo.InvariantCulture);
                 return;
             }
 

--- a/IonDotnet/Internals/Text/TextConstants.cs
+++ b/IonDotnet/Internals/Text/TextConstants.cs
@@ -566,7 +566,7 @@ namespace IonDotnet.Internals.Text
         public static int DecodeSid(StringBuilder sb)
         {
             var digits = sb.ToString(1, sb.Length);
-            return int.Parse(digits);
+            return int.Parse(digits, System.Globalization.CultureInfo.InvariantCulture);
         }
     }
 }


### PR DESCRIPTION
Interesting work you've done. I just recently started thinking about Ion and .NET, and I found your repo. Nice work indeed!

When running the unit tests on my machine (Swedish locale) they fail due to the number parsing being done in the default locale. If the tests cover 100% of the cases in http://amzn.github.io/ion-docs/docs/spec.html#real-numbers, but it fixes the failing tests and makes the test data set parse correctly regardless of locale.