### PR TITLE
Added support for targeting .NET framework 4.5+ and .NET standard 2.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,8 @@ before_install:
 script:
   - git submodule init
   - git submodule update
-  - dotnet build
   - cd IonDotnet.Tests
-  - dotnet test
+  - dotnet test IonDotnet.Tests.csproj -f netcoreapp2.0
+  - dotnet test IonDotnet.Tests.csproj -f netcoreapp2.1
+  - dotnet test IonDotnet.Tests.csproj -f netcoreapp1.0
   - cd ..

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,5 +17,4 @@ script:
   - cd IonDotnet.Tests
   - dotnet test IonDotnet.Tests.csproj -f netcoreapp2.0
   - dotnet test IonDotnet.Tests.csproj -f netcoreapp2.1
-  - dotnet test IonDotnet.Tests.csproj -f netcoreapp1.0
   - cd ..

--- a/IonDotnet.Bench/IonDotnet.Bench.csproj
+++ b/IonDotnet.Bench/IonDotnet.Bench.csproj
@@ -5,6 +5,7 @@
     <LangVersion>7.2</LangVersion>
     <ServerGarbageCollection>true</ServerGarbageCollection>
     <Configurations>Debug;Release;Perf</Configurations>
+    <IsPackable>false</IsPackable>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>

--- a/IonDotnet.Tests/Internals/Lite/IonIntLiteTest.cs
+++ b/IonDotnet.Tests/Internals/Lite/IonIntLiteTest.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using System.Data;
 using System.Numerics;
 using IonDotnet.Internals.Lite;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
@@ -81,9 +80,9 @@ namespace IonDotnet.Tests.Internals.Lite
         private static void AssertReadOnly(IIonInt ionInt)
         {
             Assert.IsTrue(ionInt.ReadOnly);
-            Assert.ThrowsException<ReadOnlyException>(() => ionInt.IntValue = int.MaxValue / 4);
-            Assert.ThrowsException<ReadOnlyException>(() => ionInt.LongValue = long.MaxValue / 4);
-            Assert.ThrowsException<ReadOnlyException>(() => ionInt.BigIntegerValue = new BigInteger(long.MaxValue));
+            Assert.ThrowsException<InvalidOperationException>(() => ionInt.IntValue = int.MaxValue / 4);
+            Assert.ThrowsException<InvalidOperationException>(() => ionInt.LongValue = long.MaxValue / 4);
+            Assert.ThrowsException<InvalidOperationException>(() => ionInt.BigIntegerValue = new BigInteger(long.MaxValue));
         }
     }
 }

--- a/IonDotnet.Tests/Internals/SharedSymbolTableTest.cs
+++ b/IonDotnet.Tests/Internals/SharedSymbolTableTest.cs
@@ -1,6 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.Data;
+using System.Text;
 using IonDotnet.Internals;
 using IonDotnet.Tests.Common;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
@@ -39,7 +39,7 @@ namespace IonDotnet.Tests.Internals
         public void InternKnownText_KeepEntry(string text)
         {
             var table = SharedSymbolTable.NewSharedSymbolTable("table", 1, null, new[] {text});
-            var extraText = string.Copy(text);
+            var extraText = new StringBuilder(text).ToString();
             Assert.AreNotSame(text, extraText);
 
             var symtok = table.Find(extraText);
@@ -53,7 +53,7 @@ namespace IonDotnet.Tests.Internals
         public void InternUnknownText_Throws()
         {
             var table = SharedSymbolTable.NewSharedSymbolTable("table", 1, null, new[] {"a", "b", "c"});
-            Assert.ThrowsException<ReadOnlyException>(() => table.Intern("d"));
+            Assert.ThrowsException<InvalidOperationException>(() => table.Intern("d"));
         }
 
         [TestMethod]

--- a/IonDotnet.Tests/Internals/SharedSymbolTableTest.cs
+++ b/IonDotnet.Tests/Internals/SharedSymbolTableTest.cs
@@ -69,7 +69,7 @@ namespace IonDotnet.Tests.Internals
                 Assert.AreSame(symbol, token.Text);
             }
 
-            var unknown = table.Find($"{string.Join(',', symbols)}key");
+            var unknown = table.Find($"{string.Join(",", symbols)}key");
             Assert.AreEqual(SymbolToken.None, unknown);
             Assert.ThrowsException<ArgumentNullException>(() => table.Find(null));
         }

--- a/IonDotnet.Tests/IonDotnet.Tests.csproj
+++ b/IonDotnet.Tests/IonDotnet.Tests.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp2.1;netcoreapp2.0;net45;net46</TargetFrameworks>
+    <TargetFrameworks>netcoreapp2.1;netcoreapp2.0;netcoreapp1.0;net45;net46</TargetFrameworks>
     <IsPackable>false</IsPackable>
     <LangVersion>latest</LangVersion>
     <Configurations>Debug;Release;Perf</Configurations>

--- a/IonDotnet.Tests/IonDotnet.Tests.csproj
+++ b/IonDotnet.Tests/IonDotnet.Tests.csproj
@@ -1,15 +1,15 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.1</TargetFramework>
+    <TargetFrameworks>netcoreapp2.1;netcoreapp2.0;net45;net46</TargetFrameworks>
     <IsPackable>false</IsPackable>
     <LangVersion>latest</LangVersion>
     <Configurations>Debug;Release;Perf</Configurations>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.7.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.8.0" />
     <PackageReference Include="Moq" Version="4.9.0" />
-    <PackageReference Include="MSTest.TestAdapter" Version="1.2.1" />
-    <PackageReference Include="MSTest.TestFramework" Version="1.2.1" />
+    <PackageReference Include="MSTest.TestAdapter" Version="1.3.2" />
+    <PackageReference Include="MSTest.TestFramework" Version="1.3.2" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\IonDotnet\IonDotnet.csproj" />

--- a/IonDotnet/Compatibility.cs
+++ b/IonDotnet/Compatibility.cs
@@ -3,7 +3,7 @@ using System.Collections.Generic;
 using System.Runtime.CompilerServices;
 using System.Text;
 
-#if NETSTANDARD2_0 || NET45 || NET46
+#if NETSTANDARD2_0 || NET45 || NETSTANDARD1_3
 namespace System.Collections.Generic
 {
     internal static class DictionaryExtensions
@@ -67,7 +67,7 @@ namespace System.IO
 }
 #endif
 
-#if NETSTANDARD2_0 || NET45 || NET46
+#if NETSTANDARD2_0 || NET45 || NETSTANDARD1_3
 namespace System.Text
 {
     internal static class EncodingExtensions
@@ -115,7 +115,7 @@ namespace System.Text
 
 #endif
 
-#if NETSTANDARD2_0 || NET45 || NET46
+#if NETSTANDARD2_0 || NET45 || NETSTANDARD1_3
 namespace System
 {
 

--- a/IonDotnet/Compatibility.cs
+++ b/IonDotnet/Compatibility.cs
@@ -68,7 +68,7 @@ namespace System.IO
 #endif
 
 #if NETSTANDARD2_0 || NET45 || NETSTANDARD1_3
-namespace System.Text
+    namespace System.Text
 {
     internal static class EncodingExtensions
     {
@@ -148,3 +148,15 @@ namespace System
     }
 }
 #endif
+
+namespace System.Threading.Tasks
+{
+    public static class TaskEx
+    {
+#if NET45
+        public static Task CompletedTask {get;} = Task.FromResult(false);
+#else
+        public static Task CompletedTask => Task.CompletedTask;
+#endif
+    }
+}

--- a/IonDotnet/Compatibility.cs
+++ b/IonDotnet/Compatibility.cs
@@ -54,9 +54,9 @@ namespace System.IO
             buf.AsSpan(0, r).CopyTo(dest);
             return r;
         }
-        public static int Write(this Stream stream, ReadOnlySpan<byte> src)
+        public static void Write(this Stream stream, ReadOnlySpan<byte> src)
         {
-            return stream.Write(src.ToArray());
+            stream.Write(src.ToArray(), 0, src.Length);
         }
         public static Threading.Tasks.Task WriteAsync(this Stream stream, Memory<byte> src)
         {

--- a/IonDotnet/Compatibility.cs
+++ b/IonDotnet/Compatibility.cs
@@ -1,0 +1,150 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Runtime.CompilerServices;
+using System.Text;
+
+#if NETSTANDARD2_0 || NET45 || NET46
+namespace System.Collections.Generic
+{
+    internal static class DictionaryExtensions
+    {
+        public static bool TryAdd<TKey, TValue>(this IDictionary<TKey, TValue> dict, TKey key, TValue value)
+        {
+            if (!dict.ContainsKey(key))
+            {
+                dict.Add(key, value);
+                return true;
+            }
+            else
+            {
+                return false;
+            }
+        }
+    }
+
+}
+#if NET45
+namespace System
+{
+    public static class DateTimeOffsetExtensions
+    {
+        private const int DaysTo1970 = 719162;
+        private const long UnixEpochTicks = TimeSpan.TicksPerDay * DaysTo1970;
+        private const long UnixEpochMilliseconds = UnixEpochTicks / TimeSpan.TicksPerMillisecond;
+
+        public static long ToUnixTimeMilliseconds(this DateTimeOffset dto)
+        {
+            // Truncate sub-millisecond precision before offsetting by the Unix Epoch to avoid
+            // the last digit being off by one for dates that result in negative Unix times
+            long milliseconds = dto.UtcDateTime.Ticks / TimeSpan.TicksPerMillisecond;
+            return milliseconds - UnixEpochMilliseconds;
+        }
+    }
+}
+#endif
+
+namespace System.IO
+{
+    internal static class StreamExtensions
+    {
+        public static int Read(this Stream stream, Span<byte> dest)
+        {
+            var buf = new byte[dest.Length];
+            var r = stream.Read(buf, 0, buf.Length);
+            buf.AsSpan(0, r).CopyTo(dest);
+            return r;
+        }
+        public static int Write(this Stream stream, ReadOnlySpan<byte> src)
+        {
+            return stream.Write(src.ToArray());
+        }
+        public static Threading.Tasks.Task WriteAsync(this Stream stream, Memory<byte> src)
+        {
+            return stream.WriteAsync(src.ToArray(), 0, src.Length);
+        }
+    }
+
+}
+#endif
+
+#if NETSTANDARD2_0 || NET45 || NET46
+namespace System.Text
+{
+    internal static class EncodingExtensions
+    {
+
+        public static string GetString(this Encoding encoding, ReadOnlySpan<byte> bytes)
+        {
+#if NET45
+            return encoding.GetString(bytes.ToArray());
+#else
+            unsafe
+            {
+                fixed (byte* ptr = bytes)
+                {
+                    return encoding.GetString(ptr, bytes.Length);
+                }
+        }
+#endif
+        }
+
+        public static int GetBytes(this Encoding encoding, ReadOnlySpan<char> chars, Span<byte> bytes)
+        {
+            unsafe
+            {
+                fixed (char* sptr = chars)
+                fixed (byte* dptr = bytes)
+                {
+                    return encoding.GetBytes(sptr, chars.Length, dptr, bytes.Length);
+                }
+            }
+        }
+
+        public static int GetByteCount(this Encoding encoding, ReadOnlySpan<char> chars)
+        {
+            unsafe
+            {
+                fixed (char* sptr = chars)
+                {
+                    return encoding.GetByteCount(sptr, chars.Length);
+                }
+            }
+        }
+    }
+}
+
+#endif
+
+#if NETSTANDARD2_0 || NET45 || NET46
+namespace System
+{
+
+    internal static class BitConverterEx
+    {
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static unsafe int SingleToInt32Bits(float value)
+        {
+            return *((int*)&value);
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static unsafe float Int32BitsToSingle(int value)
+        {
+            return *((float*)&value);
+        }
+
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static unsafe long DoubleToInt64Bits(double value)
+        {
+            return *((long*)&value);
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static unsafe double Int64BitsToDouble(long value)
+        {
+            return *((double*)&value);
+        }
+    }
+}
+#endif

--- a/IonDotnet/Internals/Binary/ManagedBinaryWriter.cs
+++ b/IonDotnet/Internals/Binary/ManagedBinaryWriter.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.Data;
 using System.Diagnostics;
 using System.IO;
 using System.Linq;
@@ -502,7 +501,7 @@ namespace IonDotnet.Internals.Binary
             {
                 var existing = Find(text);
                 if (existing != default) return existing;
-                if (IsReadOnly) throw new ReadOnlyException("Table is read-only");
+                if (IsReadOnly) throw new InvalidOperationException("Table is read-only");
 
                 return _writer.Intern(text);
             }

--- a/IonDotnet/Internals/Binary/RawBinaryReader.cs
+++ b/IonDotnet/Internals/Binary/RawBinaryReader.cs
@@ -8,6 +8,9 @@ using System.Runtime.CompilerServices;
 using System.Text;
 using IonDotnet.Conversions;
 using IonDotnet.Systems;
+#if !(NETSTANDARD2_0 || NET45 || NET46)
+using BitConverterEx = System.BitConverter;
+#endif
 
 namespace IonDotnet.Internals.Binary
 {
@@ -670,7 +673,7 @@ namespace IonDotnet.Internals.Binary
             if (length != 4 && length != 8)
                 throw new IonException($"Float length must be 0|4|8, length is {length}");
             var bits = ReadUlong(length);
-            return length == 4 ? BitConverter.Int32BitsToSingle((int) bits) : BitConverter.Int64BitsToDouble(bits);
+            return length == 4 ? BitConverterEx.Int32BitsToSingle((int) bits) : BitConverterEx.Int64BitsToDouble(bits);
         }
 
         /// <summary>

--- a/IonDotnet/Internals/Binary/RawBinaryReader.cs
+++ b/IonDotnet/Internals/Binary/RawBinaryReader.cs
@@ -8,7 +8,7 @@ using System.Runtime.CompilerServices;
 using System.Text;
 using IonDotnet.Conversions;
 using IonDotnet.Systems;
-#if !(NETSTANDARD2_0 || NET45 || NET46)
+#if !(NETSTANDARD2_0 || NET45 || NETSTANDARD1_3)
 using BitConverterEx = System.BitConverter;
 #endif
 

--- a/IonDotnet/Internals/Binary/RawBinaryWriter.cs
+++ b/IonDotnet/Internals/Binary/RawBinaryWriter.cs
@@ -7,6 +7,9 @@ using System.Numerics;
 using System.Runtime.CompilerServices;
 using System.Text;
 using System.Threading.Tasks;
+#if !(NETSTANDARD2_0 || NET45 || NET46)
+using BitConverterEx = System.BitConverter;
+#endif
 
 namespace IonDotnet.Internals.Binary
 {
@@ -456,7 +459,11 @@ namespace IonDotnet.Internals.Binary
             }
 
             //TODO is this different than java, is there a no-alloc way?
-            var buffer = value.ToByteArray(true, true);
+#if NET45 || NET46 || NETSTANDARD2_0
+            var buffer = value.ToByteArray();
+#else
+            var buffer = value.ToByteArray(isUnsigned: true, isBigEndian: true);
+#endif
             WriteTypedBytes(type, buffer);
 
             FinishValue();
@@ -493,13 +500,13 @@ namespace IonDotnet.Internals.Binary
                 //TODO requires careful testing
                 _containerStack.IncreaseCurrentContainerLength(5);
                 _dataBuffer.WriteByte(TidFloatByte | 4);
-                _dataBuffer.WriteUint32(BitConverter.SingleToInt32Bits((float) value));
+                _dataBuffer.WriteUint32(BitConverterEx.SingleToInt32Bits((float) value));
             }
             else
             {
                 _containerStack.IncreaseCurrentContainerLength(9);
                 _dataBuffer.WriteByte(TidFloatByte | 8);
-                _dataBuffer.WriteUint64(BitConverter.DoubleToInt64Bits(value));
+                _dataBuffer.WriteUint64(BitConverterEx.DoubleToInt64Bits(value));
             }
 
             FinishValue();

--- a/IonDotnet/Internals/Binary/RawBinaryWriter.cs
+++ b/IonDotnet/Internals/Binary/RawBinaryWriter.cs
@@ -231,7 +231,7 @@ namespace IonDotnet.Internals.Binary
         }
 
         //these won't be called at this level
-        Task IIonWriter.FlushAsync() => Task.CompletedTask;
+        Task IIonWriter.FlushAsync() => TaskEx.CompletedTask;
 
         void IIonWriter.Flush()
         {

--- a/IonDotnet/Internals/Binary/RawBinaryWriter.cs
+++ b/IonDotnet/Internals/Binary/RawBinaryWriter.cs
@@ -7,7 +7,7 @@ using System.Numerics;
 using System.Runtime.CompilerServices;
 using System.Text;
 using System.Threading.Tasks;
-#if !(NETSTANDARD2_0 || NET45 || NET46)
+#if !(NETSTANDARD2_0 || NET45 || NETSTANDARD1_3)
 using BitConverterEx = System.BitConverter;
 #endif
 
@@ -459,7 +459,7 @@ namespace IonDotnet.Internals.Binary
             }
 
             //TODO is this different than java, is there a no-alloc way?
-#if NET45 || NET46 || NETSTANDARD2_0
+#if NET45 || NETSTANDARD1_3 || NETSTANDARD2_0
             var buffer = value.ToByteArray();
 #else
             var buffer = value.ToByteArray(isUnsigned: true, isBigEndian: true);

--- a/IonDotnet/Internals/Lite/IonContainerLite.cs
+++ b/IonDotnet/Internals/Lite/IonContainerLite.cs
@@ -1,7 +1,6 @@
 ﻿using System;
 using System.Collections;
 using System.Collections.Generic;
-using System.Data;
 using System.Diagnostics;
 
 namespace IonDotnet.Internals.Lite
@@ -199,7 +198,7 @@ namespace IonDotnet.Internals.Lite
         private static void ValidateNewChild(IonValueLite child)
         {
             if (child.Container != null) throw new ContainedValueException();
-            if (child.ReadOnly) throw new ReadOnlyException();
+            if (child.ReadOnly) throw new InvalidOperationException("IonContainer is read-only");
 
             if (child is IIonDatagram) throw new InvalidOperationException("IonDatagram can not be inserted into another IonContainer.");
         }

--- a/IonDotnet/Internals/Lite/IonValueLite.cs
+++ b/IonDotnet/Internals/Lite/IonValueLite.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using System.Data;
 using System.Diagnostics;
 using System.IO;
 using System.Linq;
@@ -239,7 +238,7 @@ namespace IonDotnet.Internals.Lite
 
         protected void CheckLocked()
         {
-            if (IsLocked()) throw new ReadOnlyException();
+            if (IsLocked()) throw new InvalidOperationException("Value is locked");
         }
 
         protected abstract int GetHashCode(ISymbolTableProvider symbolTableProvider);

--- a/IonDotnet/Internals/LocalSymbolTable.cs
+++ b/IonDotnet/Internals/LocalSymbolTable.cs
@@ -1,7 +1,7 @@
 ﻿using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
-using System.Data;
+
 using System.Diagnostics;
 using System.Linq;
 using IonDotnet.Internals.Binary;
@@ -109,7 +109,7 @@ namespace IonDotnet.Internals
 
         private int PutSymbol(string text)
         {
-            if (IsReadOnly) throw new ReadOnlyException("Table is read-only");
+            if (IsReadOnly) throw new InvalidOperationException("Table is read-only");
             var sid = _mySymbolNames.Count + _firstLocalId;
             Debug.Assert(sid == MaxId + 1);
             Debug.Assert(!_symbolMap.ContainsKey(text));

--- a/IonDotnet/Internals/LocalSymbolTableImports.cs
+++ b/IonDotnet/Internals/LocalSymbolTableImports.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.Data;
 using System.Diagnostics;
 
 namespace IonDotnet.Internals

--- a/IonDotnet/Internals/SharedSymbolTable.cs
+++ b/IonDotnet/Internals/SharedSymbolTable.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.Data;
 using IonDotnet.Internals.Binary;
 
 namespace IonDotnet.Internals
@@ -90,7 +89,7 @@ namespace IonDotnet.Internals
         public SymbolToken Intern(string text)
         {
             var symtok = Find(text);
-            if (symtok == SymbolToken.None) throw new ReadOnlyException("Table is read-only");
+            if (symtok == SymbolToken.None) throw new InvalidOperationException("Table is read-only");
             return symtok;
         }
 

--- a/IonDotnet/Internals/Text/IonTextWriter.cs
+++ b/IonDotnet/Internals/Text/IonTextWriter.cs
@@ -412,7 +412,7 @@ namespace IonDotnet.Internals.Text
             StartValue();
 
             //TODO high-perf no-alloc encoding?
-#if NET45 || NET46 || NETSTANDARD2_0
+#if NET45 || NETSTANDARD1_3 || NETSTANDARD2_0
             var base64 = Convert.ToBase64String(value.ToArray());
 #else
             var base64 = Convert.ToBase64String(value);

--- a/IonDotnet/Internals/Text/IonTextWriter.cs
+++ b/IonDotnet/Internals/Text/IonTextWriter.cs
@@ -412,7 +412,11 @@ namespace IonDotnet.Internals.Text
             StartValue();
 
             //TODO high-perf no-alloc encoding?
+#if NET45 || NET46 || NETSTANDARD2_0
+            var base64 = Convert.ToBase64String(value.ToArray());
+#else
             var base64 = Convert.ToBase64String(value);
+#endif
 
             //TODO blob as string?
             _textWriter.Write("{{");

--- a/IonDotnet/Internals/Text/SystemTextReader.cs
+++ b/IonDotnet/Internals/Text/SystemTextReader.cs
@@ -171,13 +171,13 @@ namespace IonDotnet.Internals.Text
         private void SetInteger(Radix radix, string s)
         {
             var intBase = radix == Radix.Binary ? 2 : (radix == Radix.Decimal ? 10 : 16);
-            if (radix.IsInt(s))
+            if (radix.IsInt(s.AsSpan()))
             {
                 _v.IntValue = Convert.ToInt32(s, intBase);
                 return;
             }
 
-            if (radix.IsLong(s))
+            if (radix.IsLong(s.AsSpan()))
             {
                 _v.LongValue = Convert.ToInt64(s, intBase);
                 return;

--- a/IonDotnet/IonDotnet.csproj
+++ b/IonDotnet/IonDotnet.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;net45;net46;netcoreapp2.1</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;net45;netstandard1.3;netcoreapp2.1</TargetFrameworks>
     <RootNamespace>IonDotnet</RootNamespace>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <LangVersion>7.3</LangVersion>

--- a/IonDotnet/IonDotnet.csproj
+++ b/IonDotnet/IonDotnet.csproj
@@ -1,24 +1,13 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.1</TargetFramework>
+    <TargetFrameworks>netstandard2.0;net45;net46;netcoreapp2.1</TargetFrameworks>
     <RootNamespace>IonDotnet</RootNamespace>
-    <LangVersion>7.2</LangVersion>
-    <Configurations>Debug;Release;Perf</Configurations>
-  </PropertyGroup>
-  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
-    <LangVersion>latest</LangVersion>
-  </PropertyGroup>
-  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
-    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
-    <LangVersion>Latest</LangVersion>
-  </PropertyGroup>
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Perf|AnyCPU'">
-    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
-    <LangVersion>Latest</LangVersion>
+    <LangVersion>7.3</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="System.Buffers" Version="4.5.0" />
     <PackageReference Include="System.Memory" Version="4.5.1" />
+    <PackageReference Include="System.ValueTuple" Version="4.5.0" />
   </ItemGroup>
 </Project>

--- a/IonDotnet/Timestamp.cs
+++ b/IonDotnet/Timestamp.cs
@@ -134,7 +134,7 @@ namespace IonDotnet
             //TODO can this go wrong?
             const string minusZero = "-00:00";
             var endsWithMinusZero = false;
-            var offsetKnown = s.Contains('Z') || s.Contains('z') || s.Contains('+');
+            var offsetKnown = s.IndexOfAny(offsetSeparators) > 0;
             if (!offsetKnown)
             {
                 if (s.EndsWith(minusZero))
@@ -154,16 +154,18 @@ namespace IonDotnet
                 return new Timestamp(dto);
             }
 
-            var span = s.AsSpan();
+            var stringToParse = s;
             if (endsWithMinusZero)
             {
-                span = span.Slice(0, s.Length - minusZero.Length);
+                stringToParse = s.Substring(0, s.Length - minusZero.Length);
             }
 
-            var dt = DateTime.Parse(span);
+            var dt = DateTime.Parse(stringToParse, System.Globalization.CultureInfo.InvariantCulture);
             dt = DateTime.SpecifyKind(dt, DateTimeKind.Unspecified);
             return new Timestamp(dt);
         }
+
+        private static readonly char[] offsetSeparators = { 'Z', 'z', '+' };
 
         public override string ToString()
         {

--- a/IonDotnet/Utils/StreamExtension.cs
+++ b/IonDotnet/Utils/StreamExtension.cs
@@ -12,6 +12,9 @@ namespace IonDotnet.Utils
         /// <returns>Byte array of the written data</returns>
         public static byte[] GetWrittenBuffer(this MemoryStream memStream)
         {
+#if NETSTANDARD1_3
+            return memStream.ToArray();
+#else
             try
             {
                 var buffer = memStream.GetBuffer();
@@ -28,6 +31,7 @@ namespace IonDotnet.Utils
                 //No access to the underlying buffer
                 return memStream.ToArray();
             }
+#endif
         }
     }
 }


### PR DESCRIPTION
Thanks again for the great effort! I see this project is in very active development :) 

As I am myself evaluating Ion for some of our projects, I would be happy to help out improving this library in any way I can.

At the moment I can't unfortunately restrict myself to only supporting .NET core 2.1, I must comply with net45 and .Net Standard 2.0. 

I tried to keep the changes to a minimum (isolated to a Compatibility.cs where I can) and never sacrifice performance in the .net core 2.1 case (which would at least in theory be faster thanks to its use of Span<T> in a lot of framework methods).
I also opted to #if on the the frameworks that need backwards compatibility, so that adding newer targets in the future will not require any modifications to these.

In this PR I wanted to share my solution multi-targeting support for both of these targets in the hope that you would consider supporting them as this library progresses, which would greatly simplify adoption, at least for me.

Keep up the good work!