### PR TITLE
Json.net compatibility

### DIFF
--- a/IonDotnet.Json/Convert.cs
+++ b/IonDotnet.Json/Convert.cs
@@ -1,0 +1,184 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Numerics;
+using System.Text;
+using Newtonsoft.Json.Linq;
+
+namespace IonDotnet.Json
+{
+    internal static class Convert
+    {
+        #region Convert to JSON
+        public static JToken ToJToken(IonType type, IIonReader reader)
+        {
+            if (reader.CurrentIsNull)
+            {
+                var val = JValue.CreateNull();
+                if (type != IonType.Null)
+                {
+                    val.AddAnnotation(new IonTypeAnnotation(type));
+                }
+                return val;
+            }
+            switch (type)
+            {
+                case IonType.Struct:
+                    return StructToJObject(reader);
+                case IonType.List:
+                    return ListToJArray(reader);
+                case IonType.Bool:
+                    return new JValue(reader.BoolValue());
+                case IonType.Int:
+                    switch (reader.GetIntegerSize())
+                    {
+                        case IntegerSize.Int:
+                            return new JValue(reader.IntValue());
+                        case IntegerSize.Long:
+                            return new JValue(reader.LongValue());
+                        case IntegerSize.BigInteger:
+                            return new JValue(reader.BigIntegerValue());
+                        default:
+                            throw new InvalidDataException("Cannot map integer of size " + reader.GetIntegerSize() + " to JSON");
+                    }
+                case IonType.Float:
+                    return new JValue(reader.DoubleValue());
+                case IonType.Blob:
+                case IonType.Clob:
+                    return new JValue(reader.NewByteArray());
+                case IonType.Decimal:
+                    return new JValue(reader.DecimalValue());
+                case IonType.String:
+                    return new JValue(reader.StringValue());
+                case IonType.Timestamp:
+                    return new JValue(reader.TimestampValue().DateTimeValue);
+                case IonType.Symbol:
+                    var val = new JValue(reader.StringValue());
+                    val.ConvertToIonSymbol();
+                    return val;
+            }
+            throw new InvalidDataException("Cannot map type " + type + " to JSON");
+        }
+
+        private static JObject StructToJObject(IIonReader reader)
+        {
+            var obj = new JObject();
+            reader.StepIn();
+            for (var type = reader.MoveNext(); type != IonType.None; type = reader.MoveNext())
+            {
+                obj[reader.CurrentFieldName] = ToJToken(type, reader);
+            }
+            reader.StepOut();
+            return obj;
+        }
+
+        private static JArray ListToJArray(IIonReader reader)
+        {
+            var obj = new JArray();
+            reader.StepIn();
+            for (var type = reader.MoveNext(); type != IonType.None; type = reader.MoveNext())
+            {
+                obj.Add(ToJToken(type, reader));
+            }
+            reader.StepOut();
+            return obj;
+        }
+        #endregion
+
+        #region Convert from JSON
+
+        public static void WriteJToken(JToken token, IIonWriter writer)
+        {
+            if (token is JValue val)
+            {
+                WriteJValue(val, writer);
+            }
+            else if (token is JObject obj)
+            {
+
+            }
+            else if (token is JArray arr)
+            {
+
+            }
+            else
+            {
+                throw new ArgumentException("Unsupported JToken type " + token.Type);
+            }
+        }
+
+        private static void WriteJValue(JValue val, IIonWriter writer)
+        {
+            switch (val.Type)
+            {
+                case JTokenType.Null:
+                    var nullType = val.GetIonNullType();
+                    if (nullType != IonType.Null && nullType != IonType.None)
+                    {
+                        writer.WriteNull(nullType);
+                    }
+                    else
+                    {
+                        writer.WriteNull();
+                    }
+                    break;
+                case JTokenType.String:
+                    writer.WriteString(val.Value<string>());
+                    break;
+                case JTokenType.Integer:
+                    if (val.Value is BigInteger bi)
+                    {
+                        writer.WriteInt(bi);
+                    }
+                    else if (val.Value is long l)
+                    {
+                        writer.WriteInt(l);
+                    }
+                    else
+                    {
+                        writer.WriteInt(val.Value<int>());
+                    }
+                    break;
+                case JTokenType.Boolean:
+                    writer.WriteBool(val.Value<bool>());
+                    break;
+                case JTokenType.Bytes:
+                    writer.WriteBlob(val.Value<byte[]>());
+                    break;
+                case JTokenType.Float:
+                    if (val.Value is decimal d)
+                    {
+                        writer.WriteDecimal(d);
+                    }
+                    else
+                    {
+                        writer.WriteFloat(val.Value<double>());
+                    }
+                    break;
+                case JTokenType.Date:
+                    if (val.Value is DateTimeOffset dto)
+                    {
+                        writer.WriteTimestamp(new Timestamp(dto));
+                    }
+                    else
+                    {
+                        writer.WriteTimestamp(new Timestamp(val.Value<DateTime>()));
+                    }
+                    break;
+                case JTokenType.Guid:
+                    writer.WriteString(val.Value<Guid>().ToString());
+                    break;
+                case JTokenType.Uri:
+                    writer.WriteString(val.Value<Uri>().ToString());
+                    break;
+                case JTokenType.TimeSpan:
+                    writer.WriteString(val.Value<TimeSpan>().ToString("g", System.Globalization.CultureInfo.InvariantCulture));
+                    break;
+                default:
+                    throw new ArgumentException("Unsupported JValue type " + val.Type);
+            }
+        }
+
+        #endregion
+    }
+}

--- a/IonDotnet.Json/IonDotnet.Json.csproj
+++ b/IonDotnet.Json/IonDotnet.Json.csproj
@@ -1,0 +1,12 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFrameworks>netstandard2.0;net45;netstandard1.3;netcoreapp2.1</TargetFrameworks>
+    <LangVersion>7.3</LangVersion>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="Newtonsoft.Json" Version="11.0.2" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\IonDotnet\IonDotnet.csproj" />
+  </ItemGroup>
+</Project>

--- a/IonDotnet.Json/IonJTokenAnnotation.cs
+++ b/IonDotnet.Json/IonJTokenAnnotation.cs
@@ -1,0 +1,17 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+using Newtonsoft.Json.Linq;
+
+namespace IonDotnet.Json
+{
+    internal sealed class IonJTokenAnnotation
+    {
+        internal IonJTokenAnnotation(string annotation)
+        {
+            Annotation = annotation;
+        }
+
+        public string Annotation { get; }
+    }
+}

--- a/IonDotnet.Json/IonReaderExtensions.cs
+++ b/IonDotnet.Json/IonReaderExtensions.cs
@@ -1,0 +1,15 @@
+﻿using System;
+using System.IO;
+using System.Threading.Tasks;
+using Newtonsoft.Json.Linq;
+
+namespace IonDotnet
+{
+    public static class IonReaderExtensions
+    {
+        public static JToken ToJToken(this IIonReader reader)
+        {
+            return Json.Convert.ToJToken(reader.MoveNext(), reader);
+        }
+    }
+}

--- a/IonDotnet.Json/IonSymbolAnnotation.cs
+++ b/IonDotnet.Json/IonSymbolAnnotation.cs
@@ -1,0 +1,13 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+using Newtonsoft.Json.Linq;
+
+namespace IonDotnet.Json
+{
+    internal sealed class IonSymbolAnnotation
+    {
+        private IonSymbolAnnotation() { }
+        public static readonly IonSymbolAnnotation Default = new IonSymbolAnnotation();
+    }
+}

--- a/IonDotnet.Json/IonTypeAnnotation.cs
+++ b/IonDotnet.Json/IonTypeAnnotation.cs
@@ -1,0 +1,17 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+using Newtonsoft.Json.Linq;
+
+namespace IonDotnet.Json
+{
+    internal sealed class IonTypeAnnotation
+    {
+        internal IonTypeAnnotation(IonType type)
+        {
+            IonType = type;
+        }
+
+        public IonType IonType { get; }
+    }
+}

--- a/IonDotnet.Json/JTokenExtensions.cs
+++ b/IonDotnet.Json/JTokenExtensions.cs
@@ -1,0 +1,91 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+using IonDotnet;
+using IonDotnet.Json;
+
+namespace Newtonsoft.Json.Linq
+{
+    public static class JTokenExtensions
+    {
+        #region Writing
+
+        public static void WriteAsIon(this JToken token, IIonWriter writer)
+        {
+            IonDotnet.Json.Convert.WriteJToken(token, writer);
+        }
+
+        #endregion
+
+
+        #region Symbols
+
+        /// <summary>
+        /// Makes the value an Ion symbol. Should be used with string values only.
+        /// </summary>
+        /// <param name="value"></param>
+        public static void ConvertToIonSymbol(this JValue value)
+        {
+            if (!IsIonSymbol(value))
+                value.AddAnnotation(IonSymbolAnnotation.Default);
+        }
+        public static void ConvertFromIonSymbol(this JValue value)
+        {
+            value.RemoveAnnotations(typeof(IonSymbolAnnotation));
+        }
+        public static bool IsIonSymbol(this JValue value)
+        {
+            return value.Annotation(typeof(IonSymbolAnnotation)) != null;
+        }
+
+        #endregion
+
+
+        #region Typed nulls
+
+        /// <summary>
+        /// Returns the null-type for the specified JValue if it is null,
+        /// or IonType.None if the value is not null.
+        /// </summary>
+        /// <returns>The IonType null type.</returns>
+        public static IonType GetIonNullType(this JValue value)
+        {
+            if (value.Value == null)
+            {
+                var ann = value.Annotation(typeof(IonTypeAnnotation)) as IonTypeAnnotation;
+                return ann?.IonType ?? IonType.Null;
+            }
+            return IonType.None;
+        }
+        #endregion
+
+        #region Annotations
+
+        public static void SetIonAnnotation(this JToken token, string annotation)
+        {
+            RemoveIonAnnotations(token);
+            AddIonAnnotation(token, annotation);
+        }
+
+        public static void AddIonAnnotation(this JToken token, string annotation)
+        {
+            token.AddAnnotation(new IonJTokenAnnotation(annotation));
+        }
+
+        public static void RemoveIonAnnotations(this JToken token)
+        {
+            token.RemoveAnnotations(typeof(IonJTokenAnnotation));
+        }
+
+        public static string[] GetIonAnnotations(this JToken token)
+        {
+            var l = new List<string>();
+            foreach (IonJTokenAnnotation annotation in token.Annotations(typeof(IonJTokenAnnotation)))
+                l.Add(annotation.Annotation);
+            return l.ToArray();
+        }
+
+        #endregion
+
+    }
+}

--- a/IonDotnet.Tests/IonDotnet.Tests.csproj
+++ b/IonDotnet.Tests/IonDotnet.Tests.csproj
@@ -11,8 +11,10 @@
     <PackageReference Include="Moq" Version="4.9.0" />
     <PackageReference Include="MSTest.TestAdapter" Version="1.3.2" />
     <PackageReference Include="MSTest.TestFramework" Version="1.3.2" />
+    <PackageReference Include="Newtonsoft.Json" Version="11.0.2" />
   </ItemGroup>
   <ItemGroup>
+    <ProjectReference Include="..\IonDotnet.Json\IonDotnet.Json.csproj" />
     <ProjectReference Include="..\IonDotnet\IonDotnet.csproj" />
   </ItemGroup>
 </Project>

--- a/IonDotnet.Tests/Json/JTokenFromReaderTest.cs
+++ b/IonDotnet.Tests/Json/JTokenFromReaderTest.cs
@@ -1,0 +1,208 @@
+﻿using System;
+using System.IO;
+using System.Linq;
+using System.Numerics;
+using System.Text;
+using IonDotnet;
+using IonDotnet.Internals.Text;
+using IonDotnet.Json;
+using IonDotnet.Tests.Common;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Moq;
+using Newtonsoft.Json.Linq;
+
+namespace IonDotnet.Tests.Json
+{
+    [TestClass]
+    public class JTokenFromReaderTest
+    {
+        [TestMethod]
+        public void TrivialStruct()
+        {
+            //empty struct {}
+            var trivial = DirStructure.ReadDataFile("text/trivial.ion");
+            var text = Encoding.UTF8.GetString(trivial);
+
+            var reader = new UserTextReader(text);
+
+            var token = reader.ToJToken();
+            Assert.IsInstanceOfType(token, typeof(JObject));
+            var obj = (JObject)token;
+            Assert.AreEqual(0, obj.Count);
+        }
+
+        /// <summary>
+        /// Test for single-value bool 
+        /// </summary>
+        [TestMethod]
+        [DataRow("true", true)]
+        [DataRow("false", false)]
+        public void SingleBool(string text, bool value)
+        {
+            var reader = new UserTextReader(text);
+            var token = reader.ToJToken();
+            Assert.IsInstanceOfType(token, typeof(JValue));
+            Assert.AreEqual(new JValue(value), token);
+        }
+
+
+        [TestMethod]
+        [DataRow("1234567890", 1234567890)]
+        [DataRow("4611686018427387903", long.MaxValue / 2)]
+        public void SingleNumber(string text, long value)
+        {
+            var reader = new UserTextReader(text);
+            var token = reader.ToJToken();
+            Assert.IsInstanceOfType(token, typeof(JValue));
+            Assert.AreEqual(new JValue(value), token);
+        }
+
+        [TestMethod]
+        public void OneBoolInStruct()
+        {
+            //simple datagram: {yolo:true}
+            var oneBool = DirStructure.ReadDataFile("text/onebool.ion");
+            var reader = new UserTextReader(new MemoryStream(oneBool));
+
+            var token = reader.ToJToken();
+            Assert.IsInstanceOfType(token, typeof(JObject));
+            var obj = (JObject)token;
+            Assert.AreEqual(1, obj.Count);
+            Assert.AreEqual("yolo", obj.Properties().Single().Name);
+            Assert.AreEqual(new JValue(true), obj["yolo"]);
+        }
+
+        [TestMethod]
+        public void FlatScalar()
+        {
+            //a flat struct of scalar values:
+            //boolean:true
+            //str:"yes"
+            //integer:123456
+            //longInt:int.Max*2
+            //bigInt:long.Max*10
+            //double:2213.1267567f
+            var flatScalar = DirStructure.ReadDataFile("text/flat_scalar.ion");
+
+            var reader = new UserTextReader(new MemoryStream(flatScalar));
+            var token = reader.ToJToken();
+            Assert.IsInstanceOfType(token, typeof(JObject));
+            var obj = (JObject)token;
+            Assert.AreEqual(6, obj.Count);
+
+
+
+            Assert.AreEqual(new JValue(true), obj["boolean"]);
+            Assert.AreEqual(new JValue("yes"), obj["str"]);
+            Assert.AreEqual(new JValue(123456), obj["integer"]);
+            Assert.AreEqual(new JValue(int.MaxValue * 2L), obj["longInt"]);
+            Assert.AreEqual(new JValue(new BigInteger(long.MaxValue) * 10), obj["bigInt"]);
+            Assert.AreEqual(new JValue(2213.1267567), obj["double"]);
+        }
+
+        [TestMethod]
+        public void FlatIntList()
+        {
+            //a flat list of ints [123,456,789]
+            var flatListInt = DirStructure.ReadDataFile("text/flatlist_int.ion");
+
+            var reader = new UserTextReader(new MemoryStream(flatListInt));
+            var token = reader.ToJToken();
+            Assert.IsInstanceOfType(token, typeof(JArray));
+            var obj = (JArray)token;
+            Assert.AreEqual(3, obj.Count);
+            Assert.AreEqual(new JValue(123), obj[0]);
+            Assert.AreEqual(new JValue(456), obj[1]);
+            Assert.AreEqual(new JValue(789), obj[2]);
+        }
+
+        //        [TestMethod]
+        //        public void ReadAnnotations_SingleField()
+        //        {
+        //            // a singlefield structure with annotations
+        //            // {withannot:years::months::days::hours::minutes::seconds::18}
+        //            var annotSingleField = DirStructure.ReadDataFile("text/annot_singlefield.ion");
+        //            var converter = new SaveAnnotationsReaderRoutine();
+        //            var reader = new UserTextReader(new MemoryStream(annotSingleField), converter);
+        //            ReaderTestCommon.ReadAnnotations_SingleField(reader, converter);
+        //        }
+
+        [TestMethod]
+        public void SingleSymbol()
+        {
+            //struct with single symbol
+            //{single_symbol:'something'}
+            var data = DirStructure.ReadDataFile("text/single_symbol.ion");
+
+            var reader = new UserTextReader(new MemoryStream(data));
+            var token = reader.ToJToken();
+
+            Assert.IsInstanceOfType(token, typeof(JObject));
+            var obj = (JObject)token;
+
+            var val = (JValue)obj["single_symbol"];
+
+            Assert.IsTrue(val.IsIonSymbol());
+            Assert.AreEqual(new JValue("something"), val);
+
+        }
+
+        [TestMethod]
+        public void SingleIntList()
+        {
+            var data = DirStructure.ReadDataFile("text/single_int_list.ion");
+            var reader = new UserTextReader(new MemoryStream(data));
+
+            var token = reader.ToJToken();
+            Assert.IsInstanceOfType(token, typeof(JArray));
+            var obj = (JArray)token;
+            Assert.AreEqual(5, obj.Count);
+
+            Assert.AreEqual(new JValue(1234), obj[0]);
+            Assert.AreEqual(new JValue(5678), obj[1]);
+            Assert.AreEqual(new JValue(6421), obj[2]);
+            Assert.AreEqual(new JValue(-2147483648), obj[3]);
+            Assert.AreEqual(new JValue(2147483647), obj[4]);
+        }
+
+        /// <summary>
+        /// Test for a typical json-style message
+        /// </summary>
+        [TestMethod]
+        public void Combined1()
+        {
+            var data = DirStructure.ReadDataFile("text/combined1.ion");
+            var reader = new UserTextReader(new MemoryStream(data));
+
+            var token = reader.ToJToken();
+            Assert.IsInstanceOfType(token, typeof(JObject));
+            var obj = (JObject)token;
+
+            Assert.AreEqual(new JValue("file"), obj["menu"]["id"]);
+            Assert.AreEqual(new JValue("Open"), obj["menu"]["popup"][0]);
+            Assert.AreEqual(new JValue("Load"), obj["menu"]["popup"][1]);
+            Assert.AreEqual(new JValue("Close"), obj["menu"]["popup"][2]);
+            Assert.AreEqual(new JValue("enddeep"), obj["menu"]["deep1"]["deep2"]["deep3"]["deep4val"]);
+            Assert.AreEqual(new JValue(1234), obj["menu"]["positions"][0]);
+            Assert.AreEqual(new JValue(5678), obj["menu"]["positions"][1]);
+            Assert.AreEqual(new JValue(90), obj["menu"]["positions"][2]);
+        }
+
+        [TestMethod]
+        public void Struct_OneBlob()
+        {
+            var data = DirStructure.ReadDataFile("text/struct_oneblob.ion");
+            var reader = new UserTextReader(new MemoryStream(data));
+
+            var expected = Convert.FromBase64String("AQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQ==");
+
+            var token = reader.ToJToken();
+            Assert.IsInstanceOfType(token, typeof(JObject));
+            var obj = (JObject)token;
+            var val = (JValue)obj["blobbbb"];
+
+            Assert.AreEqual(JTokenType.Bytes, val.Type);
+            Assert.AreEqual(Convert.ToBase64String(expected), Convert.ToBase64String(val.Value<byte[]>()));
+        }
+    }
+}

--- a/IonDotnet.sln
+++ b/IonDotnet.sln
@@ -11,6 +11,8 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "IonDotnet.Bench", "IonDotne
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "IonDotnet.Serialization", "IonDotnet.Serialization\IonDotnet.Serialization.csproj", "{4721DD4D-EEBB-4E5C-9A5C-E0FD1990B3C7}"
 EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "IonDotnet.Json", "IonDotnet.Json\IonDotnet.Json.csproj", "{BB100389-9A99-483F-9852-73AD760EB552}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -33,6 +35,10 @@ Global
 		{4721DD4D-EEBB-4E5C-9A5C-E0FD1990B3C7}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{4721DD4D-EEBB-4E5C-9A5C-E0FD1990B3C7}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{4721DD4D-EEBB-4E5C-9A5C-E0FD1990B3C7}.Release|Any CPU.Build.0 = Release|Any CPU
+		{BB100389-9A99-483F-9852-73AD760EB552}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{BB100389-9A99-483F-9852-73AD760EB552}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{BB100389-9A99-483F-9852-73AD760EB552}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{BB100389-9A99-483F-9852-73AD760EB552}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE


### PR DESCRIPTION
This is a standalone class library that provides integration between IonDotNet and JSON.Net. The rationale is that IonDotNet can reuse existing reflection mappers without change, which is a huge productivity gain if the system already needs to support JSON as a serialization method.

In addition to supporting the JSON expressive power, some Ion concepts have been added to e.g. add annotations and allow enum types to be mapped to symbols (this something that an application developer needs to implement though, this library only provides the basic framework for implementing it).

I am not sure if this library belongs here or should be a separate project altogether, but the benefits of integrating it would be to allow a faster pace of development. This also shortcuts the need for a bespoke reflection mapper in IonDotNet (JSON.Net already have a proven one), even though a datacontract serializer would eventually be ideal to have.